### PR TITLE
Updates * naming convention to make exception for any constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ In method signatures, there should be a space after the scope (-/+ symbol). Ther
 
 Variables should be named as descriptively as possible. Single letter variable names should be avoided except in `for()` loops. 
 
-Asterisks indicating pointers belong with the variable, i.e. `NSString *text` not `NSString* text` or `NSString * text`, except in the case of global string constants.
+Asterisks indicating pointers belong with the variable, i.e. `NSString *text` not `NSString* text` or `NSString * text`, except in the case of constants.
 
 Property definitions should be used in place of naked instance variables whenever possible. Direct instance variable access should be avoided except in `dealloc` methods and within custom setters and getters.
 


### PR DESCRIPTION
The current README makes an exception to the `NSString *text` convention for global `NSString` constants, but the convention should be generalized to all constants.

For example, in a non-global, static constant:

``` objc
- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
{
    static NSString * const cellIdentifier = @"CellIdentifier";
    // Prepare cell
}
```

Or when using `const` to [prevent re-assignment of a pointer](http://stackoverflow.com/questions/3196491/objective-c-const-nsstring-vs-nsstring-const):

``` objc
NSString * const authorName = @"Stephen Levy";
text = @"Bret Victor"; // Illegal; 'Read-only variable is not assignable'
```
## 

``` objc
NSString const *authorName = @"Paul Krugman";
text = @"Max Tagher"; // Legal
```
