### PR TITLE
Added More Detail on Init Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ Block comments should generally be avoided, as code should be as self-documentin
 ```objc
 - (instancetype)init {
 self = [super init]; // or call the designated initalizer
-    if (self) {
-    
-    }
+if (self) {
+    // Custom initialization    
+}
 return self;
 }
 ```


### PR DESCRIPTION
The topic of how our `init` methods are structured recently came up on the team internally, so I thought I'd add our general practice to the guide we do this, because assignment in conditions is just too clever:

``` objc
self = [super init];
if (self) {

}
return self;
```

Not this:

``` objc
if (self = [super init]) {

}
return self;
```
