### PR TITLE
Make variable name consistent across example

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ NSNumber *buildingZIPCode = @10018;
 NSArray *names = [NSArray arrayWithObjects:@"Brian", @"Matt", @"Chris", @"Alex", @"Steve", @"Paul", nil];
 NSDictionary *productManagers = [NSDictionary dictionaryWithObjectsAndKeys: @"Kate", @"iPhone", @"Kamal", @"iPad", @"Bill", @"Mobile Web", nil];
 NSNumber *shouldUseLiterals = [NSNumber numberWithBool:YES];
-NSNumber *ZIPCode = [NSNumber numberWithInteger:10018];
+NSNumber *buildingZIPCode = [NSNumber numberWithInteger:10018];
 ```
 
 ## CGRect Functions


### PR DESCRIPTION
Updated the ZIPCode variable to be buildingZIPCode to match the previous name given in the example.
