### PR TITLE
Set `NSError`'s to `nil` on declaration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ When methods return an error parameter by reference, switch on the returned valu
 
 **For example:**
 ```objc
-NSError *error;
+NSError *error = nil;
 if (![self trySomethingWithError:&error]) {
     // Handle Error
 }
@@ -119,7 +119,7 @@ if (![self trySomethingWithError:&error]) {
 
 **Not:**
 ```objc
-NSError *error;
+NSError *error = nil;
 [self trySomethingWithError:&error];
 if (error) {
     // Handle Error


### PR DESCRIPTION
If the NSError is not set to `nil`, the `if(error)` conditional could execute garbage memory if `trySomethingWithError` does not set an error.
