### PR TITLE
Adds german version of NYTimes Objective-C style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## NYTimes Objective-C Style Guide
+# NYTimes Objective-C Style Guide
 
 This style guide outlines the coding conventions of the iOS team at The New York Times. We welcome your feedback in [issues](https://github.com/NYTimes/objetive-c-style-guide/issues), [pull requests](https://github.com/NYTimes/objetive-c-style-guide/pulls) and [tweets](https://twitter.com/nytimesmobile). Also, [we're hiring](http://jobs.nytco.com/job/New-York-iOS-Developer-Job-NY/2572221/).
 

--- a/README_de-GER.md
+++ b/README_de-GER.md
@@ -290,7 +290,7 @@ CGFloat height = frame.size.height;
 
 ## Konstanten
 
-Konstanten werden gegenüber in-line Zeichenketten oder Zahlen bevorzugt, da sie eine einfache Wiederverwendung von gemeinsam verwendeten Variablen erlauben. Zudem können sie einfach ersetzt werden, ohne sie zuvor mit Finde und Ersetze ausfindig gemacht zu haben. Konstanten sollten als `static` Konstanten und nicht mit #define deklariert werden, so fern sie nicht explizit in Makros verwendet werden.
+Konstanten werden gegenüber in-line Zeichenketten oder Zahlen bevorzugt, da sie eine einfache Wiederverwendung von gemeinsam verwendeten Variablen erlauben. Zudem können sie einfach ersetzt werden, ohne sie zuvor mit Finde und Ersetze ausfindig gemacht zu haben. Konstanten sollten als `static` Konstanten ud nicht mit #define deklariert werden, so fern sie nicht explizit in Makros verwendet werden.
 
 **Beispiel:**
 


### PR DESCRIPTION
This pull request adds the german translation for the NYTimes Objective-C style guide.
