### PR TITLE
Fix some minor typos

### DIFF
--- a/README-FRA.md
+++ b/README-FRA.md
@@ -165,7 +165,7 @@ NSString *headline;s
 
 #### Qualifiers de Variables
 
-En ce qui concerne les qualifiers de variables [introduits avec ARC](https://developer.apple.com/library/ios/releasenotes/objectivec/rn-transitioningtoarc/Introduction/Introduction.html#//apple_ref/doc/uid/TP40011226-CH1-SW4), le qualifer (`__strong`, `__weak`, `__unsafe_unretained`, `__autoreleasing`) doit être placé entre l'astérisque et le nom de la variable, par ex., `NSString * __weak text`.
+En ce qui concerne les qualifiers de variables [introduits avec ARC](https://developer.apple.com/library/ios/releasenotes/objectivec/rn-transitioningtoarc/Introduction/Introduction.html#//apple_ref/doc/uid/TP40011226-CH1-SW4), le qualifier (`__strong`, `__weak`, `__unsafe_unretained`, `__autoreleasing`) doit être placé entre l'astérisque et le nom de la variable, par ex., `NSString * __weak text`.
 
 ## Nommage
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Property definitions should be used in place of naked instance variables wheneve
 
 #### Variable Qualifiers
 
-When it comes to the variable qualifiers [introduced with ARC](https://developer.apple.com/library/ios/releasenotes/objectivec/rn-transitioningtoarc/Introduction/Introduction.html#//apple_ref/doc/uid/TP40011226-CH1-SW4), the qualifer (`__strong`, `__weak`, `__unsafe_unretained`, `__autoreleasing`) should be placed between the asterisks and the variable name, e.g., `NSString * __weak text`. 
+When it comes to the variable qualifiers [introduced with ARC](https://developer.apple.com/library/ios/releasenotes/objectivec/rn-transitioningtoarc/Introduction/Introduction.html#//apple_ref/doc/uid/TP40011226-CH1-SW4), the qualifier (`__strong`, `__weak`, `__unsafe_unretained`, `__autoreleasing`) should be placed between the asterisks and the variable name, e.g., `NSString * __weak text`. 
 
 ## Naming
 
@@ -230,7 +230,7 @@ Block comments should generally be avoided, as code should be as self-documentin
 
 ```objc
 - (instancetype)init {
-    self = [super init]; // or call the designated initalizer
+    self = [super init]; // or call the designated initializer
     if (self) {
         // Custom initialization
     }

--- a/README_de-GER.md
+++ b/README_de-GER.md
@@ -229,7 +229,7 @@ Blockkommentare sollten generell vermieden werden, da Code (abgesehen von ein pa
 
 ```objc
 - (instancetype)init {
-    self = [super init]; // oder Aufruf des designated initalizer
+    self = [super init]; // oder Aufruf des designated initializer
     if (self) {
         // Custom initialization
     }


### PR DESCRIPTION
Merely changes "qualifer" to "qualifier" and "initalizer" to "initializer" in a few instances.
