### PR TITLE
Singleton Example Defensiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Singleton objects should use a thread-safe pattern for creating their shared ins
 
    static dispatch_once_t onceToken;
    dispatch_once(&onceToken, ^{
-      sharedInstance = [[self alloc] init];
+      sharedInstance = [[[self class] alloc] init];
    });
 
    return sharedInstance;


### PR DESCRIPTION
Modify the singleton example to call `class` to better support cases where the `+class` method is override to return a different `Class`. Gotta love inheritance. And by love, [I mean despise](https://vimeo.com/111942573).