### PR TITLE
Changed boolValue to Dot Notation Since It is Now a Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,14 +390,14 @@ if (someObject == nil) {
 
 ```objc
 if (isAwesome)
-if (![someObject boolValue])
+if (!someNumber.boolValue)
 ```
 
 **Not:**
 
 ```objc
 if (isAwesome == YES) // Never do this.
-if ([someObject boolValue] == NO)
+if (someNumber.boolValue == NO)
 ```
 
 -----


### PR DESCRIPTION
`boolValue` was previously defined as a method on `NSNumber`. It is now a `@property` and therefore should use a `.` accessor to follow the guide.