### PR TITLE
Adds link to Wikimedia style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,3 +461,4 @@ If ours doesn’t fit your tastes, have a look at some other style guides:
 * [CocoaDevCentral](http://cocoadevcentral.com/articles/000082.php)
 * [Luke Redpath](http://lukeredpath.co.uk/blog/2011/06/28/my-objective-c-style-guide/)
 * [Marcus Zarra](http://www.cimgf.com/zds-code-style-guide/)
+* [Wikimedia](https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/iOS/ObjectiveCStyleGuide)


### PR DESCRIPTION
Wikimedia’s iOS team maintains a style guide and I think it’d be nice to include them in the “ Other Objective-C Style Guides” section.