### PR TITLE
Explicitly allow a blank space at beginning of a method

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ else {
     // Do something else
 }
 ```
-* There should be exactly one blank line between methods to aid in visual clarity and organization. Whitespace within methods should separate functionality, but often there should probably be new methods.
+* There should be exactly one blank line between methods to aid in visual clarity and organization.
+* Whitespace within methods should be used to separate functionality (though often this can indicate an opportunity to split the method into several, smaller methods). In methods with long or verbose names, a single line of whitespace may be used to provide visual separation before the method’s body.
 * `@synthesize` and `@dynamic` should each be declared on new lines in the implementation.
 
 ## Conditionals


### PR DESCRIPTION
The guide has never forbidden this, but it would be nice to explicitly allow a line of whitespace to separate a method's name and body.