### PR TITLE
Remove "feedback via tweets" link to @NYTimesMobile account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NYTimes Objective-C Style Guide
 
-This style guide outlines the coding conventions of the iOS teams at The New York Times. We welcome your feedback in [issues](https://github.com/NYTimes/objective-c-style-guide/issues), [pull requests](https://github.com/NYTimes/objective-c-style-guide/pulls) and [tweets](https://twitter.com/nytimesmobile). Also, [we’re hiring](http://www.nytco.com/careers/).
+This style guide outlines the coding conventions of the iOS teams at The New York Times. We welcome your feedback in [issues](https://github.com/NYTimes/objective-c-style-guide/issues) and [pull requests](https://github.com/NYTimes/objective-c-style-guide/pulls). Also, [we’re hiring](http://www.nytco.com/careers/).
 
 Thanks to all of [our contributors](https://github.com/NYTimes/objective-c-style-guide/graphs/contributors).
 


### PR DESCRIPTION
I don't know who monitors that account. Issues and PRs will ensure this guide's maintainers see feedback in a timely fashion.