### PR TITLE
Added new rule for methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,21 +138,21 @@ Some of Apple’s APIs write garbage values to the error parameter (if non-NULL)
 
 ## Methods
 
-In method signatures, there SHOULD be a space after the scope (`-` or `+` symbol). There SHOULD be a space between the method segments.
+* In method signatures, there SHOULD be a space after the scope (`-` or `+` symbol). There SHOULD be a space between the method segments.
 
 **For example:**
 ```objc
 - (void)setExampleText:(NSString *)text image:(UIImage *)image;
 ```
 
-Methods exceeding 80 characters SHOULD be represented like a form with a new line after each argument
+* Methods exceeding 80 characters SHOULD be represented like a form with a new line after each argument
 
 **For example:**
 ```objc
 - (void)setExampleText:(NSString *)text 
                  image:(UIImage *)image 
                  color:(UIColor *)color 
-       alternativeText: (NSString *)altText;
+       alternativeText:(NSString *)altText;
 ```
 
 ## Variables

--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ In method signatures, there SHOULD be a space after the scope (`-` or `+` symbol
 - (void)setExampleText:(NSString *)text image:(UIImage *)image;
 ```
 
+Methods exceeding 80 characters SHOULD be represented like a form with a new line after each argument
+
+**For example:**
+```objc
+- (void)setExampleText:(NSString *)text 
+                 image:(UIImage *)image 
+                 color:(UIColor *)color 
+       alternativeText: (NSString *)altText;
+```
+
 ## Variables
 
 Variables SHOULD be named descriptively, with the variable’s name clearly communicating what the variable _is_ and pertinent information a programmer needs to use that value properly.


### PR DESCRIPTION
Methods exceeding 80 characters SHOULD be represented like a form with a new line after each argument.