### PR TITLE
Fixed Broken Links in All Languages

### DIFF
--- a/README-FRA.md
+++ b/README-FRA.md
@@ -263,7 +263,7 @@ NSNumber *buildingZIPCode = [NSNumber numberWithInteger:10018];
 
 ## Fonctions `CGRect`
 
-En accédant à `x`, `y`, `width`, ou `height` d'un `CGRect`, utilisez toujours les [fonctions `CGGeometry`](http://developer.apple.com/library/ios/#documentation/graphicsimaging/reference/CGGeometry/Reference/reference.html) au lieu de l'accès direct au membre struct. Extrait de la référence Apple pour `CGGeometry`:
+En accédant à `x`, `y`, `width`, ou `height` d'un `CGRect`, utilisez toujours les [fonctions `CGGeometry`](https://developer.apple.com/documentation/coregraphics/cggeometry) au lieu de l'accès direct au membre struct. Extrait de la référence Apple pour `CGGeometry`:
 
 > Toutes les fonctions décrites dans cette référence qui prendre les structures de data CGRect comme donnée standardise implicitement ces rectangles avant de calculer leurs résultats. Pour cette raison, votre application devrait éviter de lire et écrire directement la donnée sauvegardée dans la structure de données CGRect. À la place, utilisez les fonctions décrites ici pour manipuler les rectangles et pour recupérer leurs caractériques.
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -268,7 +268,7 @@ NSNumber *buildingZIPCode = [NSNumber numberWithInteger:10018];
 ## <a name='cgrect-functions'>CGRect Functions</a> [원문](https://github.com/NYTimes/objective-c-style-guide#cgrect-functions)
 
 
-`CGRect`의 `x`, `y`, `width` 또는 `height`를 접근하는 경우, 직접 struct 멤버에 접근하지말고 [`CGGeometry` functions](http://developer.apple.com/library/ios/#documentation/graphicsimaging/reference/CGGeometry/Reference/reference.html)를 항상 사용하세요. 애플의 `CGGeometry` 참조 : 
+`CGRect`의 `x`, `y`, `width` 또는 `height`를 접근하는 경우, 직접 struct 멤버에 접근하지말고 [`CGGeometry` functions](https://developer.apple.com/documentation/coregraphics/cggeometry)를 항상 사용하세요. 애플의 `CGGeometry` 참조 : 
 
 
 > 결과를 계산하기 전에 표준화된 사각형에 내제되어 입력된 CGRect 데이타 구조를 가지는 참조에서 모든 함수가 설명됩니다. 이러한 이유로 어플리케이션은 CGRect 데이타 구조에 저장된 데이타를 직접 읽고 쓰는 것을 피해야 합니다. 대신 사각형을 다루고 그 특성을 검색하도록 여기에 기술된 함수를 사용합니다.

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ NSNumber *buildingZIPCode = [NSNumber numberWithInteger:10018];
 
 ## `CGRect` Functions
 
-When accessing the `x`, `y`, `width`, or `height` of a `CGRect`, code MUST use the [`CGGeometry` functions](http://developer.apple.com/library/ios/#documentation/graphicsimaging/reference/CGGeometry/Reference/reference.html) instead of direct struct member access. From Apple's `CGGeometry` reference:
+When accessing the `x`, `y`, `width`, or `height` of a `CGRect`, code MUST use the [`CGGeometry` functions](https://developer.apple.com/documentation/coregraphics/cggeometry) instead of direct struct member access. From Apple's `CGGeometry` reference:
 
 > All functions described in this reference that take CGRect data structures as inputs implicitly standardize those rectangles before calculating their results. For this reason, your applications should avoid directly reading and writing the data stored in the CGRect data structure. Instead, use the functions described here to manipulate rectangles and to retrieve their characteristics.
 

--- a/README_de-GER.md
+++ b/README_de-GER.md
@@ -267,7 +267,7 @@ NSNumber *buildingZIPCode = [NSNumber numberWithInteger:10018];
 
 ## CGRect Funktionen
 
-Beim Zugriff auf `x`, `y`, `width` oder `height` eines CGRect sollten statt des direkt Zugriffs auf die `struct` Werte, immer die [`CGGeometry` Funktionen](http://developer.apple.com/library/ios/#documentation/graphicsimaging/reference/CGGeometry/Reference/reference.html) verwendet werden.
+Beim Zugriff auf `x`, `y`, `width` oder `height` eines CGRect sollten statt des direkt Zugriffs auf die `struct` Werte, immer die [`CGGeometry` Funktionen](https://developer.apple.com/documentation/coregraphics/cggeometry) verwendet werden.
 
 > All functions described in this reference that take CGRect data structures as inputs implicitly standardize those rectangles before calculating their results. For this reason, your applications should avoid directly reading and writing the data stored in the CGRect data structure. Instead, use the functions described here to manipulate rectangles and to retrieve their characteristics.
 

--- a/README_es-MX.md
+++ b/README_es-MX.md
@@ -318,7 +318,7 @@ NSNumber *buildingZIPCode = [NSNumber numberWithInteger:10018];
 
 ## Funciones `CGRect`
 
-Cuando se accede a las propiedades `x`, `y`, `width` o `height` de un `CGRect`, siempre se debe de utilizar las funciones de [`CGGeometry` functions](http://developer.apple.com/library/ios/#documentation/graphicsimaging/reference/CGGeometry/Reference/reference.html) en lugar de accederlas directamente. De la referencia de Apple sobre `CGGeometry`:
+Cuando se accede a las propiedades `x`, `y`, `width` o `height` de un `CGRect`, siempre se debe de utilizar las funciones de [`CGGeometry` functions](https://developer.apple.com/documentation/coregraphics/cggeometry) en lugar de accederlas directamente. De la referencia de Apple sobre `CGGeometry`:
 
 > Todas las funciones descritas en esta referencia que toman las estructuras de datos de CGRect como entradas implícitamente estandarizan los rectángulos antes de calcular los resultados. Por esta razón, sus aplicaciones deben de evitar leer y escribir directamente la información guardada en la estructura de datos de CGRect. En lugar de eso, se deben de utilizar las funciones descritas aquí para manipular rectángulos y obtener sus características.
 

--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -296,7 +296,7 @@ NSNumber *buildingZIPCode = [NSNumber numberWithInteger:10018];
 
 ## `CGRect` 関数
 
-`CGRect`の`x`,`y`,`width`,`height`にアクセスする際、構造体メンバーに直接アクセスせずに**必ず** [`CGGeometry`関数](http://developer.apple.com/library/ios/#documentation/graphicsimaging/reference/CGGeometry/Reference/reference.html)を使うこと。Appleの`CGGeometry` レファレンスより：
+`CGRect`の`x`,`y`,`width`,`height`にアクセスする際、構造体メンバーに直接アクセスせずに**必ず** [`CGGeometry`関数](https://developer.apple.com/documentation/coregraphics/cggeometry)を使うこと。Appleの`CGGeometry` レファレンスより：
 
 > このレファレンス中の関数でCGRectデータ構造を入力とするものは、矩形を暗黙的に標準化してから結果を計算する。そのため、アプリケーションはCGRectデータ構造内のデータを直接読み書きすべきではない。かわりに、ここに記載されている関数を使って矩形計算し、値を取得すること。
 

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -317,7 +317,7 @@ NSNumber *buildingZIPCode = [NSNumber numberWithInteger:10018];
 
 ## Funções CGRect
 
-Ao acessar `x`, `y`, `width` ou `height` de um `CGRect`, sempre use as [funções `CGGeometry`](http://developer.apple.com/library/ios/#documentation/graphicsimaging/reference/CGGeometry/Reference/reference.html) ao invés de acessar os membros diretamente. Referência da Apple sobre as funções `CGGeometry`:
+Ao acessar `x`, `y`, `width` ou `height` de um `CGRect`, sempre use as [funções `CGGeometry`](https://developer.apple.com/documentation/coregraphics/cggeometry) ao invés de acessar os membros diretamente. Referência da Apple sobre as funções `CGGeometry`:
 
 > All functions described in this reference that take CGRect data structures as inputs implicitly standardize those rectangles before calculating their results. For this reason, your applications should avoid directly reading and writing the data stored in the CGRect data structure. Instead, use the functions described here to manipulate rectangles and to retrieve their characteristics.
 

--- a/README_zh-Hans.md
+++ b/README_zh-Hans.md
@@ -310,7 +310,7 @@ CGFloat width = frame.size.width;
 CGFloat height = frame.size.height;
 ```
 
-[CGRect-Functions_1]:http://developer.apple.com/library/ios/#documentation/graphicsimaging/reference/CGGeometry/Reference/reference.html
+[CGRect-Functions_1]:https://developer.apple.com/documentation/coregraphics/cggeometry
 
 ## 常量
 


### PR DESCRIPTION
https://developer.apple.com/library/content/#documentation/graphicsimaging/reference/CGGeometry/Reference/reference.html 

changed to

https://developer.apple.com/documentation/coregraphics/cggeometry