### PR TITLE
Updated dot notation syntax to use dot-notation for all properties (in latest API)

### DIFF
--- a/README-FRA.md
+++ b/README-FRA.md
@@ -43,14 +43,14 @@ La notation pointée doit **toujours** être utilisée pour lire ou modifier les
 
 **Par exemple:**
 ```objc
-view.backgroundColor = [UIColor orangeColor];
-[UIApplication sharedApplication].delegate;
+view.backgroundColor = UIColor.orangeColor;
+UIApplication.sharedApplication.delegate;
 ```
 
 **Non pas:**
 ```objc
 [view setBackgroundColor:[UIColor orangeColor]];
-UIApplication.sharedApplication.delegate;
+[UIApplication sharedApplication].delegate;
 ```
 
 ## Espacement

--- a/README-ko.md
+++ b/README-ko.md
@@ -45,14 +45,14 @@
 
 **For example:**
 ```objc
-view.backgroundColor = [UIColor orangeColor];
-[UIApplication sharedApplication].delegate;
+view.backgroundColor = UIColor.orangeColor;
+UIApplication.sharedApplication.delegate;
 ```
 
 **Not:**
 ```objc
 [view setBackgroundColor:[UIColor orangeColor]];
-UIApplication.sharedApplication.delegate;
+[UIApplication sharedApplication].delegate;
 ```
 
 ## <a name='spacing'>Spacing</a> [원문](https://github.com/NYTimes/objective-c-style-guide#spacing)

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Dot notation is RECOMMENDED over bracket notation for getting and setting proper
 
 **For example:**
 ```objc
-view.backgroundColor = [UIColor orangeColor];
-[UIApplication sharedApplication].delegate;
+view.backgroundColor = UIColor.orangeColor;
+UIApplication.sharedApplication.delegate;
 ```
 
 **Not:**
 ```objc
 [view setBackgroundColor:[UIColor orangeColor]];
-UIApplication.sharedApplication.delegate;
+[UIApplication sharedApplication].delegate;
 ```
 
 ## Spacing

--- a/README_de-GER.md
+++ b/README_de-GER.md
@@ -43,13 +43,13 @@ Die Punktnotation sollte **immer** verwendet werden, um auf Properties zuzugreif
 
 **Beispiel:**
 ```objc
-view.backgroundColor = [UIColor orangeColor];
-[UIApplication sharedApplication].delegate;
+view.backgroundColor = UIColor.orangeColor;
+UIApplication.sharedApplication.delegate;
 ```
 **Nicht:**
 ```objc
 [view setBackgroundColor:[UIColor orangeColor]];
-UIApplication.sharedApplication.delegate;
+[UIApplication sharedApplication].delegate;
 ```
 
 ## Abstände

--- a/README_es-MX.md
+++ b/README_es-MX.md
@@ -46,15 +46,15 @@ Hay que utilizar punto **siempre** que se acceda o altere alguna propiedad. En t
 **Por ejemplo:**
 
 ```objc
-view.backgroundColor = [UIColor orangeColor];
-[UIApplication sharedApplication].delegate;
+view.backgroundColor = UIColor.orangeColor;
+UIApplication.sharedApplication.delegate;
 ```
 
 **Incorrecto:**
 
 ```objc
 [view setBackgroundColor:[UIColor orangeColor]];
-UIApplication.sharedApplication.delegate;
+[UIApplication sharedApplication].delegate;
 ```
 
 ## Espaciado

--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -44,14 +44,14 @@ Appleからいくつかのスタイルガイド情報が提供されています
 
 **良い例：**
 ```objc
-view.backgroundColor = [UIColor orangeColor];
-[UIApplication sharedApplication].delegate;
+view.backgroundColor = UIColor.orangeColor;
+UIApplication.sharedApplication.delegate;
 ```
 
 **悪い例：**
 ```objc
 [view setBackgroundColor:[UIColor orangeColor]];
-UIApplication.sharedApplication.delegate;
+[UIApplication sharedApplication].delegate;
 ```
 
 ## スペーシング

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -48,14 +48,14 @@ Utilize o ponto **sempre** quando for acessar e alterar uma propriedade. Em todo
 
 **Exemplo correto:**
 ```objc
-view.backgroundColor = [UIColor orangeColor];
-[UIApplication sharedApplication].delegate;
+view.backgroundColor = UIColor.orangeColor;
+UIApplication.sharedApplication.delegate;
 ```
 
 **Inadequado:**
 ```objc
 [view setBackgroundColor:[UIColor orangeColor]];
-UIApplication.sharedApplication.delegate;
+[UIApplication sharedApplication].delegate;
 ```
 
 ## Espaçamento

--- a/README_zh-Hans.md
+++ b/README_zh-Hans.md
@@ -50,14 +50,14 @@
 
 **推荐：**
 ```objc
-view.backgroundColor = [UIColor orangeColor];
-[UIApplication sharedApplication].delegate;
+view.backgroundColor = UIColor.orangeColor;
+UIApplication.sharedApplication.delegate;
 ```
 
 **反对：**
 ```objc
 [view setBackgroundColor:[UIColor orangeColor]];
-UIApplication.sharedApplication.delegate;
+[UIApplication sharedApplication].delegate;
 ```
 
 ## 间距


### PR DESCRIPTION
Updated the code sample for the **Dot Notation Syntax** section to use dot-notation syntax for all properties in the latest API.  As a result, changed some (correct) usage of dot-notation syntax in the _“Not:”_ code sample to use square-bracket syntax, for clarity.

The reason behind these code samples originally having square-bracket syntax for some calls in the _“For example:”_ sample and dot-notation syntax for those calls in the _“Not:”_ sample was that formerly, all class-level getters in Obj-C were just plain methods.  That changed in Xcode 8 _(and continues in the current iOS/macOS API as of Xcode 9.4.1 and the latest Xcode 10 beta)_ with the introduction of `class`-level properties in Objective-C, and the consequent updating of the iOS/macOS APIs by Apple.  Now both `UIColor`'s `orangeColor` and and `UIApplication`'s `sharedApplication` are true properties:

```objc
// From the macOS SDK documentation that ships with Xcode 8.4.1:

@property(class, strong, readonly) NSColor *orangeColor;

@property(class, nonatomic, readonly) UIApplication *sharedApplication;
```
While it could be understandable that NYTimes might want to keep calls to things like `[UIApplication sharedApplication]` using square-bracket syntax for consistency with their/your existing codebase, that causes a problem for potential new Obj-C programmers using your guide to help them learn Obj-C, since they'll read _“Dot notation is RECOMMENDED […] for getting […] properties”_ but then check the official Obj-C docs and see that `sharedApplication`, leading to confusion over the apparent non-sensical nature of your style guide.  It doesn't help that **Dot Notation Syntax** is the very first section in the style guide, and could turn off new programmers to the validity of your style guide _(despite the fact that a few years ago for Xcode ≤7, the style guide was accurate)_.

So in summary, I believe it makes sense to update code samples to use dot-notation syntax where Apple has updated the iOS/macOS APIs to use properties.  Even in an era of Swift, Obj-C is still receiving updates and consistency clean-up by Apple — _which is a wonderful thing for us long-time Obj-C devs_ — and so it makes sense to embrace that.

Changes made:

* In the **Dot Notation Syntax** section of each translated `README….md`, changed the _“For example:”_ code sample to use `UIColor.orangeColor` & `UIApplication.sharedApplication`, and changed the _“Not:”_ code sample to use `[UIColor orangeColor]` & `[UIApplication sharedApplication]`.